### PR TITLE
Fixing compilation issues

### DIFF
--- a/Decoders/decode_ddl.c
+++ b/Decoders/decode_ddl.c
@@ -26,7 +26,7 @@
 
 #include "rdseed.h"
 #include "ddl.h"
- 
+
 static char *blk_data_ptr;
 static char *cur_data_ptr;
 static union

--- a/Include/ddl.h
+++ b/Include/ddl.h
@@ -1,3 +1,6 @@
+#ifndef HEADER_DDL
+#define HEADER_DDL
+
 struct ext_byte
 {
 	int num_bytes;
@@ -157,5 +160,4 @@ struct prim_struct
 	struct prim_struct *next;
 };
  
-struct prim_struct *key[50];
- 
+#endif //HEADER_DDL

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,9 @@ CC = cc
 #CFLAGS = -O -m64 -g -mmacosx-version-min=10.4
 
 #else
-CFLAGS = -O -m64 -g
+CFLAGS = -O -m64 -g -Wno-incompatible-pointer-types -Wno-implicit-int -Wno-implicit-function-declaration -lnsl -ltirpc
 
-INCLUDE    = -I../Include
+INCLUDE    = -I../Include -I/usr/include/tirpc
 
 CFLAGSLINE = "$(INCLUDE) $(CFLAGS)"
 

--- a/Makefile
+++ b/Makefile
@@ -33,16 +33,16 @@ CC = cc
 #CFLAGS = -O -m64 -g -mmacosx-version-min=10.4
 
 #else
-CFLAGS = -O -m64 -g -Wno-incompatible-pointer-types -Wno-implicit-int -Wno-implicit-function-declaration -lnsl -ltirpc
+CFLAGS = -O -m64 -g -Wno-incompatible-pointer-types -Wno-implicit-int -Wno-implicit-function-declaration
 
-INCLUDE    = -I../Include -I/usr/include/tirpc
+INCLUDE    = -I../Include -I/usr/include/ntirpc/
 
 CFLAGSLINE = "$(INCLUDE) $(CFLAGS)"
 
 # comment out one or the other of the LDFLAGS
 
 # Default LDFLAGS should be good for Linux, Mac OSX, PC etc.
-LDFLAGS = -lm -lc
+LDFLAGS = -lm -lc -ltirpc
 
 # Uncomment this line for Solaris
 #LDFLAGS = -lm -lc -lnsl

--- a/Printers/print_key.c
+++ b/Printers/print_key.c
@@ -2,7 +2,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
- 
+
 #define TRUE 1
 #define FALSE 0
  

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # rdseed
 rdseed – Read an FDSN SEED format volume
 
+### Install the following libraries
+
+```bash
+apt install make g++ libnsl-dev libntirpc-dev
+```
+
 ### NAME
 
 rdseed - Read an FDSN SEED format volume


### PR DESCRIPTION
I saw that there was a missing include folder, so I added the following path : `-I/usr/include/ntirpc/`.
Then there was a missing library link too, so I added the following (only for Linux) : `LDFLAGS = -lm -lc -ltirpc`.

Furthermore, there was some warnings that newer C compilers (gcc 14 in my case) don't really like, so I ignored the following : 
`-Wno-incompatible-pointer-types -Wno-implicit-int -Wno-implicit-function-declaration`.

Finally, there was a variable named :
```c
struct prim_struct *key[50];`
```
That was defined inside a header... Which I don't know when was this possible. Nevertheless, seeing that no reference of this variable was given anywhere in the C files, i just deleted this line (I tried to use an `extern` at first but because it was not used.).